### PR TITLE
Fixed bug in ipa_kinit so expired kerberos tickets are not considered…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 * Added new resources `ipa::user` and `ipa_user` to manage IPA users and their home directories.
   Contributed by Nick Maludy (@nmaludy)
+  
+* Fixed bug in `ipa_kinit` where exired kerberos tickets weren't getting filtered out
+  resulting in `ipa_kinit` thinking a valid ticket existed for a user since it was in
+  the list.
+  Contributed by Nick Maludy (@nmaludy)
 
 ## v0.1.1 (2021-01-15)
 * Fixed bug in client install where /etc/nsswitch.conf was declared twice for file_line

--- a/lib/puppet/provider/ipa_kinit/default.rb
+++ b/lib/puppet/provider/ipa_kinit/default.rb
@@ -24,8 +24,12 @@ Puppet::Type.type(:ipa_kinit).provide(:default, parent: Puppet::Provider::Ipa) d
       output = klist('-l')
       Puppet.debug("klist got output: #{output}")
       output.lines.each do |line|
-        next if line.start_with?('Principal name')
+        # compare downcase in case (for some reason) they change the text in a new version
+        next if line.downcase.start_with?('principal name')
         next if line.start_with?('--------------')
+        # filter out expired tickets
+        next if line.downcase.include?('(expired)')
+
         line_parts = line.split(' ')
         principal_name = line_parts[0]
         principal_parts = principal_name.split('@')


### PR DESCRIPTION
… valid

Didn't realize this was a thing...

```
[root@freeipa ~]# klist -l                                                                                                                                  
Principal name                 Cache name
--------------                 ----------
admin@IPA.MALUDY.HOME          KCM:0 (Expired)
```

These expired tickets are not filtered out so it will run `kinit` and create a valid ticket.