### PR TITLE
changing regex to match everything after the ':'

### DIFF
--- a/manifests/install/client.pp
+++ b/manifests/install/client.pp
@@ -110,7 +110,7 @@ class ipa::install::client (
     ~> file_line { '/etc/nsswitch.conf_automount':
       path   => '/etc/nsswitch.conf',
       line   => 'automount:  files sss',
-      match  => '^automount: ',
+      match  => '^automount:.*',
       notify => Ipa::Helpers::Flushcache["server_${$facts['fqdn']}"],
     }
   }
@@ -119,7 +119,7 @@ class ipa::install::client (
   file_line { '/etc/nsswitch.conf_sudoers':
     path   => '/etc/nsswitch.conf',
     line   => 'sudoers:  files sss',
-    match  => '^sudoers: ',
+    match  => '^sudoers:.*',
     notify => Ipa::Helpers::Flushcache["server_${$facts['fqdn']}"],
   }
 


### PR DESCRIPTION
Say for example nsswitch.conf has:

```
automount:  foo
sudoers:  bar
```

The current resource will create new lines lines for `automount` and `sudoers` which causes issues due to duplication. e.g:
```
automount:  foo
sudoers:  bar

automount:  files sss
sudoers:  files sss
```

 This change enables the resource to actually update the values by matching everything after the `:` following the key names. So puppet will write it properly with only:
 
 ```
automount:  files sss
sudoers:  files sss
 ```