### PR TITLE
Update SSL ciphers and protocols for RHEL 8.5+

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -266,7 +266,6 @@ class ipa (
     } else {
       $final_configure_dns_server = $configure_dns_server
     }
-
   }
 
   class {'ipa::validate_params':}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -266,8 +266,9 @@ class ipa (
     } else {
       $final_configure_dns_server = $configure_dns_server
     }
+
+    class {'ipa::validate_params':}
+    -> class {'ipa::install':}
   }
 
-  class {'ipa::validate_params':}
-  -> class {'ipa::install':}
 }

--- a/manifests/install/server.pp
+++ b/manifests/install/server.pp
@@ -111,8 +111,9 @@ class ipa::install::server (
   }
 
   # harden the SSL ciphers and protocols for Apache using the NSS module
-  $nss_ssl_ciphers = join($ipa::nss_ssl_ciphers, ',')
-  $nss_ssl_protocols = join($ipa::nss_ssl_protocols, ',')
+  $nss_ssl_ciphers = join($ipa::params::nss_ssl_ciphers, ',')
+  $nss_ssl_protocols = join($ipa::params::nss_ssl_protocols, ',')
+
   if $nss_ssl_ciphers != undef and !$nss_ssl_ciphers.empty() {
     file_line { 'nss_ssl_cipher':
       path   => '/etc/httpd/conf.d/nss.conf',
@@ -121,6 +122,7 @@ class ipa::install::server (
       notify => Service['httpd'],
     }
   }
+
   if $nss_ssl_protocols != undef and !$nss_ssl_protocols.empty() {
     file_line { 'nss_ssl_protocols':
       path   => '/etc/httpd/conf.d/nss.conf',

--- a/manifests/install/server/dirsrv.pp
+++ b/manifests/install/server/dirsrv.pp
@@ -1,8 +1,8 @@
 # Private class to manage IPA directory services
 class ipa::install::server::dirsrv (
   String $admin_password        = $ipa::admin_password,
-  Optional[Array[String]] $ds_ssl_ciphers = $ipa::ds_ssl_ciphers,
-  Optional[String] $ds_ssl_min_version    = $ipa::ds_ssl_min_version,
+  Optional[Array[String]] $ds_ssl_ciphers = $ipa::params::ds_ssl_ciphers,
+  Optional[String] $ds_ssl_min_version    = $ipa::params::ds_ssl_min_version,
   String $ds_password           = $ipa::ds_password,
   String $ipa_realm             = $ipa::final_realm,
 ) inherits ipa {

--- a/manifests/install/server/pki.pp
+++ b/manifests/install/server/pki.pp
@@ -1,7 +1,7 @@
 # Private class to manage IPA PKI certificate server (Dogtag)
 class ipa::install::server::pki (
-  Optional[String] $ssl_protocol_range = $ipa::pki_ssl_protocol_range,
-  Optional[Array[String]] $ssl_ciphers   = $ipa::pki_ssl_ciphers,
+  Optional[String] $ssl_protocol_range = $ipa::params::pki_ssl_protocol_range,
+  Optional[Array[String]] $ssl_ciphers = $ipa::params::pki_ssl_ciphers,
 ) inherits ipa {
   $config_file = '/etc/pki/pki-tomcat/server.xml'
 

--- a/manifests/install/server/replica.pp
+++ b/manifests/install/server/replica.pp
@@ -18,11 +18,6 @@ class ipa::install::server::replica (
     --unattended
     | EOC
 
-  # Set puppet fact for IPA role
-  facter::fact { 'ipa_role':
-    value => $ipa_role,
-  }
-
   contain ipa::helpers::firewalld
 
   if str2bool($facts['ipa_installed']) != true {
@@ -46,10 +41,15 @@ class ipa::install::server::replica (
       require     => Class['ipa::helpers::firewalld'],
       notify      => Ipa::Helpers::Flushcache["server_${$facts['fqdn']}"],
     }
-  }
 
-  facter::fact { 'ipa_installed':
-    value => true,
+    # Set fact for IPA installed if successful
+    -> facter::fact { 'ipa_installed':
+      value => true,
+    }
+    # Set puppet fact for IPA role
+    -> facter::fact { 'ipa_role':
+      value => $ipa_role,
+    }
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -77,8 +77,10 @@ class ipa::params {
           # Failed to bind to server!
           # Failed to get keytab
           # child exited with 9
-          $ds_ssl_ciphers         = $ds_ssl_ciphers_tls12 + $ds_ssl_ciphers_tls13
-          $ds_ssl_min_version     = $ds_ssl_min_version_tls12
+          #$ds_ssl_ciphers         = $ds_ssl_ciphers_tls12 + $ds_ssl_ciphers_tls13
+          #$ds_ssl_min_version     = $ds_ssl_min_version_tls12
+          $ds_ssl_ciphers         = []
+          $ds_ssl_min_version     = ''
 
           # IPA on RHEL/CentOS 8 switched to mod_ssl, away from mod_nss
           # mod_ssl in RHEL/CentOS 8 uses the "system" cryto policy for its ciphers and protocols
@@ -93,12 +95,14 @@ class ipa::params {
           # you _must_ set both the TLS 1.2 and 1.3 ciphers here though, otherwise you'll get an error
           # when registering your clients:
           # Joining realm failed: HTTP POST to URL 'https://freeipa.maludy.home:443/ipa/xml' failed.  libcurl failed even to execute the HTTP transaction, explaining:  SSL certificate problem: EE certificate key too weak
-          $pki_ssl_ciphers        = $pki_ssl_ciphers_tls12 + $pki_ssl_ciphers_tls13
+          #$pki_ssl_ciphers        = $pki_ssl_ciphers_tls12 + $pki_ssl_ciphers_tls13
+          $pki_ssl_ciphers        = []
           # PKI Tomcat doesn't, yet, support tls1_3 protocol, so leave it to 1.2
           # if you try to set it to tls1_2:tls1_3 pki-tomcatd@pki-tomcat.service service will fail to start
-          $pki_ssl_protocol_range = $pki_ssl_protocol_range_tls12
+          #$pki_ssl_protocol_range = $pki_ssl_protocol_range_tls12
+          $pki_ssl_protocol_range = ''
         }
-        default: { fail("ERROR: Unsupported RHEL version: ${facts['os']['full']}") }
+        default: { fail("ERROR: Unsupported RHEL release: ${facts['os']['release']['full']}") }
       }
       $ldaputils_package_name    = 'openldap-clients'
       $ipa_client_package_name   = 'ipa-client'
@@ -139,7 +143,7 @@ class ipa::params {
           $pki_ssl_ciphers        = undef
           $pki_ssl_protocol_range = undef
         }
-        default: { fail("ERROR: Unsupported Ubuntu version: ${facts['os']['full']}") }
+        default: { fail("ERROR: Unsupported Ubuntu release: ${facts['os']['release']['full']}") }
       }
       $ldaputils_package_name    = 'ldap-utils'
       $ipa_client_package_name   = 'freeipa-client'


### PR DESCRIPTION
This update disables ssl ciphers and protocols for RHEL 8 hosts.  RHEL 8.5+ uses global crypto policies for dirsrv, pki-tomcat, and apache.

These changes work for installing the replica-server on RHEL 8.6 host.